### PR TITLE
Remove support of PHP 5.5 and below.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: php
 php:
+  - "7.2"
+  - "7.1"
+  - "7.0"
   - "5.6"
-  - "5.5"
-  - "5.4"
   
 before_install:
  - curl -sS https://getcomposer.org/installer | php
@@ -12,4 +13,4 @@ before_script:
 
 script:
  - (cd tests ; phpunit)
- 
+

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,10 @@
    "name": "alex.oleshkevich/fast-xml-parser",
    "description": "Fast SAX XML parser for PHP",
     "require": {
-        "php": ">=5.4.0"
+        "php": ">=5.6.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "*"
     },
    "autoload": {
         "psr-0": {

--- a/src/FastXml/Parser.php
+++ b/src/FastXml/Parser.php
@@ -18,7 +18,7 @@ class Parser
      * Currently aggregated data.
      * @var array
      */
-    protected $currentData = array();
+    protected $currentData = [];
 
     /**
      * @var string
@@ -29,7 +29,7 @@ class Parser
      * Tags to exclude from result
      * @var array
      */
-    protected $ignoreTags = array();
+    protected $ignoreTags = [];
 
     /**
      * Endpoint of XML item.
@@ -176,7 +176,7 @@ class Parser
     {
         if ($name == $this->endTag) {
             $this->callbackHandler->onItemParsed($this->currentData);
-            $this->currentData = array();
+            $this->currentData = [];
         }
     }
     

--- a/tests/FastXmlTest/ParserTest.php
+++ b/tests/FastXmlTest/ParserTest.php
@@ -4,9 +4,8 @@ namespace FastXmlTest;
 
 use FastXml\CallbackHandler\GenericHandler;
 use FastXml\Parser;
-use PHPUnit_Framework_TestCase;
 
-class ParserTest extends PHPUnit_Framework_TestCase
+class ParserTest extends \PHPUnit\Framework\TestCase
 {
 
     public function testParser()
@@ -54,7 +53,7 @@ class ParserTest extends PHPUnit_Framework_TestCase
         $self = $this;
         $handler = new GenericHandler;
         $handler->setOnProgressCallback(function ($bytesProcessed, $bytesTotal) use ($self) {
-            $this->assertContains($bytesProcessed, array(100, 200, 300, 363));
+            $this->assertContains($bytesProcessed, [100, 200, 300, 363]);
         });
         $parser = new Parser($handler);
         $parser->setReadBuffer(100);


### PR DESCRIPTION
Fixed tests for php 7.x, but now it crashes on 5.5, because of new phpunit syntax.  
PHP5.5 is not supporting for a 1.5 years. Actual version is 7.2.

http://php.net/supported-versions.php