### PR TITLE
add installation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ Key features:
   
 [![Build Status](https://travis-ci.org/alex-oleshkevich/php-fast-xml-parser.svg)](https://travis-ci.org/alex-oleshkevich/php-fast-xml-parser)
 
+## Installation
+
+```
+composer require alex.oleshkevich/fast-xml-parser
+```
+
 Example & Tutorial
 --------------
 


### PR DESCRIPTION
easy copy-paste for lazy people.

aaalso it's slightly harder to figure out the composer name for this library, because the name on GitHub is `alex-oleshkevich` but the name on composer is `alex.oleshkevich`  , i actually wasted a minute figuring out why 
```composer require alex-oleshkevich/php-fast-xml-parser```
didn't work.